### PR TITLE
#36: Solve concurrency issue for random annotations

### DIFF
--- a/web_app/analisis/views.py
+++ b/web_app/analisis/views.py
@@ -213,7 +213,6 @@ def annotate(request):
 
     if request.method == 'POST':
         create_annotation(request.POST)
-        #return redirect('annotate')
 
     context = {
         'tweet_relation_id' : tweet_relation.id,

--- a/web_app/analisis/views.py
+++ b/web_app/analisis/views.py
@@ -66,13 +66,13 @@ class AnswerViewSet(viewsets.ModelViewSet):
 
 def add_id_to_in_progress_ids(_id):    
     from django.core.cache import cache
-    cache.set('IN_PROGRESS_IDS', [_id] + cache.get('IN_PROGRESS_IDS',[]),timeout=None)# 1 hour
+    cache.set('IN_PROGRESS_IDS', [_id] + cache.get('IN_PROGRESS_IDS',[]), timeout=36000)# 1 hour
     print('Add id to in progress ids:', cache.get('IN_PROGRESS_IDS',[]))
     return None
 
 def remove_id_from_in_progress_ids(input_id):
     from django.core.cache import cache
-    cache.set('IN_PROGRESS_IDS', [_id for _id in cache.get('IN_PROGRESS_IDS',[]) if _id != input_id ], timeout=None)
+    cache.set('IN_PROGRESS_IDS', [_id for _id in cache.get('IN_PROGRESS_IDS',[]) if _id != input_id ], timeout=36000)
     print('Remove _id to in progress ids:',cache.get('IN_PROGRESS_IDS',[]))
     return None
 
@@ -112,9 +112,9 @@ def get_random_tweet_relation(annotator_id: int) -> TweetRelation:
     trs_annotated_once_count = get_trs_count(1, annotator_id)
     trs_annotated_zero_count = get_trs_count(0, annotator_id)
 
-    #if trs_annotated_twice_count > 100:
-    #    trs = get_trs(2, annotator_id)
-    if trs_annotated_once_count > 100:
+    if trs_annotated_twice_count > 0:
+        trs = get_trs(2, annotator_id)
+    if trs_annotated_once_count > 0:
         trs = get_trs(1, annotator_id)
     elif trs_annotated_zero_count > 0:
         trs = get_trs(0, annotator_id)

--- a/web_app/analisistweets/settings.py
+++ b/web_app/analisistweets/settings.py
@@ -129,6 +129,7 @@ CACHES = {
     }
 }
 
+CACHE_TIMEOUT = 36000
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/web_app/analisistweets/settings.py
+++ b/web_app/analisistweets/settings.py
@@ -123,6 +123,9 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         'LOCATION': 'in_process_tweet_relations',
+        'OPTIONS': {
+            'MAX_ENTRIES': 1000
+        }
     }
 }
 

--- a/web_app/analisistweets/settings.py
+++ b/web_app/analisistweets/settings.py
@@ -119,6 +119,13 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'in_process_tweet_relations',
+    }
+}
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/web_app/fixtures/annotators.yaml
+++ b/web_app/fixtures/annotators.yaml
@@ -1,0 +1,30 @@
+- model: auth.User
+  pk: 2
+  fields:
+    username: user1
+    password: pbkdf2_sha256$150000$Q4LmlYEBOd0I$/VHAx34hshytKqWzilU1NT0Gg61A4Gh+ARFg5lJ/7XQ=
+- model: analisis.Annotator
+  pk: 2
+  fields:
+    id: 2
+    name: usser1
+- model: auth.User
+  pk: 3
+  fields:
+    username: user2
+    password: pbkdf2_sha256$150000$n8nyubzF5HQH$WOnievFAC5+jdDKe3T+MkUx624Apsye3aj86UdYoN7U=
+- model: analisis.Annotator
+  pk: 3
+  fields:
+    id: 3
+    name: user2
+- model: auth.User
+  pk: 4
+  fields:
+    username: user3
+    password: pbkdf2_sha256$150000$0OUyAzIhg9vT$J7dDKlU8Lm1BtrpW4fnPgs59gif322NgcdwvtiujEKM=
+- model: analisis.Annotator
+  pk: 4
+  fields:
+    id: 4
+    name: user3


### PR DESCRIPTION
- Add basic django cache functions to handle concurrent annotations.
- Allow to show TweetRelations annotated or not.
- Config cache use using local memory and max 1000 entries.

fixes #36 